### PR TITLE
Refactor for updated doctl release processes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: c
 script: asdf plugin-test doctl $TRAVIS_BUILD_DIR 'doctl version'
+before_install:
+  - shellcheck bin/*
 before_script:
   - git clone https://github.com/asdf-vm/asdf.git
   - . asdf/asdf.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: c
 script: asdf plugin-test doctl $TRAVIS_BUILD_DIR 'doctl version'
-before_install:
-  - shellcheck bin/*
 before_script:
   - git clone https://github.com/asdf-vm/asdf.git
   - . asdf/asdf.sh

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/maristgeek/asdf-doctl.svg?branch=master)](https://travis-ci.org/maristgeek/asdf-doctl)
 
-[doctl](https://github.com/digitalocean/doctl) plugin for [asdf](https://github.com/asdf-vm/asdf) version manager
+[doctl](https://github.com/digitalocean/doctl) plugin for [asdf](https://github.com/asdf-vm/asdf) version manager. Check doctl's README for latest supported installation options but if they do not suit your needs this can work for 1.21.1+.
 
 ## Install
 

--- a/bin/install
+++ b/bin/install
@@ -4,33 +4,23 @@ set -e
 set -o pipefail
 
 install_doctl() {
-  local version=$2
-  local install_path=$3
-  local bin_install_path="${install_path}/bin"
-  local binary_path="${bin_install_path}/doctl"
-  local url_prefix="https://github.com/digitalocean/doctl/releases/download/v${version}"
-  local checksum_url
-  checksum_url="${url_prefix}"/$(get_filename "${version}" 'sha256')
-  local tarball_url
-  tarball_url="${url_prefix}"/$(get_filename "${version}" 'tar.gz')
-  local checksum_download_path
-  local tarball_download_path
-  local tmp_download_dir
+  local -r version=$2
+  local -r install_path=$3
+  local -r tmp_download_dir=$4
 
-  if [ "${TMPDIR}" = "" ]; then
-    tmp_download_dir=$(mktemp -d -t doctl_XXXXXX)
-  else
-    tmp_download_dir="${TMPDIR}"
-  fi
+  local -r bin_install_path="${install_path}/bin"
+  local -r binary_path="${bin_install_path}/doctl"
 
-  checksum_download_path="${tmp_download_dir}"/$(get_filename "${version}" 'sha256')
-  tarball_download_path="${tmp_download_dir}"/$(get_filename "${version}" 'tar.gz')
+  local platform
+  local download_url
+  local download_path
 
-  echo "Downloading doctl from ${tarball_url}"
-  curl -Lo "${tarball_download_path}" "${tarball_url}"
+  platform=$(get_platform)
+  download_url=$(get_download_url "$version" "$platform")
+  download_path="${tmp_download_dir}"/$(get_filename "$version" "$platform")
 
-  echo "Downloading checksum from ${checksum_url}"
-  curl -Lo "${checksum_download_path}" "${checksum_url}"
+  echo "Downloading doctl from ${download_url}"
+  curl -Lo "${download_path}" "${download_url}"
 
   echo "Creating bin directory"
   mkdir -p "${bin_install_path}"
@@ -39,29 +29,34 @@ install_doctl() {
   rm -f "${binary_path}" 2>/dev/null || true
 
   echo "Copying binary"
-  tar xf "${tarball_download_path}" -C "${bin_install_path}"
+  tar xf "${download_path}" -C "${bin_install_path}"
   chmod +x "${binary_path}"
 
-  echo "Verifying binary"
-  pushd "${bin_install_path}"
-  shasum --algorithm 256 --check "${checksum_download_path}"
-  popd
-
   echo "Cleaning up downloads"
-  rm -f "${checksum_download_path}" "${tarball_download_path}"
+  rm -f "${download_path}"
 }
 
 get_platform() {
-  [ "Linux" = "$(uname)" ] && echo "linux" || echo "darwin-10.6"
+  uname | tr '[:upper:]' '[:lower:]'
 }
 
 get_filename() {
-  local version=$1
-  local extension=$2
-  local platform
-  platform="$(get_platform)"
+  local -r version=$1
+  local -r platform=$2
 
-  echo "doctl-${version}-${platform}-amd64.${extension}"
+  echo "doctl-${version}-${platform}-amd64.tar.gz"
 }
 
-install_doctl "${ASDF_INSTALL_TYPE}" "${ASDF_INSTALL_VERSION}" "${ASDF_INSTALL_PATH}"
+get_download_url() {
+  local -r version=$1
+  local -r platform=$2
+  local filename
+  filename=$(get_filename "$version" "$platform")
+
+  echo "https://github.com/digitalocean/doctl/releases/download/v${version}/${filename}"
+}
+
+# probably should verify ASDF_INSTALL_VERSION is 1.21.1+
+tmp_download_dir="$(mktemp -d -t 'asdf_XXXXXXXX')"
+trap 'rm -rf "${tmp_download_dir}"' EXIT
+install_doctl "${ASDF_INSTALL_TYPE}" "${ASDF_INSTALL_VERSION}" "${ASDF_INSTALL_PATH}" "$tmp_download_dir"

--- a/bin/list-all
+++ b/bin/list-all
@@ -10,7 +10,7 @@ cmd="$cmd $releases_path"
 # stolen from https://github.com/rbenv/ruby-build/pull/631/files#diff-fdcfb8a18714b33b07529b7d02b54f1dR942
 function sort_versions() {
   sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' | \
-    LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
+    LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}' | sed '1,/^1.21.0$/d'
 }
 
 # Fetch all tag names, and get only second column. Then remove all unnecesary characters.


### PR DESCRIPTION
- Only list versions newer than 1.21.0
- Refactor install script to simplified Darwin platform naming (changed in 1.21.1)
- Drop support for downloading and comparing against checksums since older Linux distros lack `--ignore-missing` support in `shasum`

Resolves #1.