### PR TITLE
List all should show all versions

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -10,7 +10,7 @@ cmd="$cmd $releases_path"
 # stolen from https://github.com/rbenv/ruby-build/pull/631/files#diff-fdcfb8a18714b33b07529b7d02b54f1dR942
 function sort_versions() {
   sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' | \
-    LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}' | sed '1,/^1.21.0$/d'
+    LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
 }
 
 # Fetch all tag names, and get only second column. Then remove all unnecesary characters.


### PR DESCRIPTION
Now that we are long past 1.21.xx we should show all versions of doctl that are available.